### PR TITLE
Fix admin doc for installation

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -14,7 +14,7 @@ maintainers = ["Lapineige"]
 license = "AGPL-3.0-only"
 website = "https://gancio.org"
 demo = "https://demo.gancio.org/"
-admindoc = "https://gancio.org/install/"
+admindoc = "https://gancio.org/install"
 userdoc = "https://gancio.org/usage"
 code = "https://framagit.org/les/gancio"
 


### PR DESCRIPTION
## Problem

- Clicking on the admin documentation link produces 403

## Solution

- Remove trailing slash

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
